### PR TITLE
Release attributes for CAS 2.0 protocol

### DIFF
--- a/cas/src/main/resources/templates/protocol/2.0/casServiceValidationSuccess.html
+++ b/cas/src/main/resources/templates/protocol/2.0/casServiceValidationSuccess.html
@@ -1,0 +1,35 @@
+<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas' th:inline="text">
+    <cas:authenticationSuccess>
+        <cas:user>[[${principal.id}]]</cas:user>
+        <cas:attributes>
+            <th:block th:each="val : ${principal.attributes}">
+                <div th:with="key=${#strings.escapeXml(#strings.substringBefore(val, '='))},value=${#strings.escapeXml(#strings.substringAfter(val, '='))}" th:remove="tag">
+                    <th:block th:switch="${#strings.substring(value,0,1)}" th:remove="tag">
+                        <th:block th:case="[">
+                            <th:block th:with="formattedValue=${#strings.replace(value, ', ', '|')}">
+                                <th:block th:each="group : ${#strings.listSplit(formattedValue, '|')}">
+                                    <th:block th:with="remRightBrace=${#strings.replace(group, '[', '')}">
+                                        <th:block th:with="remBothBraces=${#strings.replace(remRightBrace, ']', '')}">
+                                            <html th:inline="text"  th:remove="tag">
+                                                <[[${#strings.prepend(key, 'cas:')}]]>[[${remBothBraces}]]<[[${#strings.prepend(key, '/cas:')}]]>
+                                            </html>
+                                        </th:block>
+                                    </th:block>
+                                </th:block>
+                            </th:block>
+                        </th:block>
+                        <th:block th:case="*">
+                            <html th:inline="text"  th:remove="tag">
+                                <[[${#strings.prepend(key, 'cas:')}]]>[[${value}]]<[[${#strings.prepend(key, '/cas:')}]]>
+                            </html>
+                        </th:block>
+                    </th:block>
+                </div>
+            </th:block>
+        </cas:attributes>
+        <cas:proxyGrantingTicket th:if="${pgtIou}">[[${pgtIou}]]</cas:proxyGrantingTicket>
+        <cas:proxies th:if="${not #lists.isEmpty(chainedAuthentications)}">
+            <cas:proxy th:each="proxy : ${chainedAuthentications}">[[${proxy.principal.id}]]</cas:proxy>
+        </cas:proxies>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>


### PR DESCRIPTION
CAS Client 2.0 protocol does not release attributes in CAS 5.x, need to add casServiceValidationSuccess.html to make it happen (Currently only SAML 1.0 & CAS 3.0 protocol)

See 
- https://groups.google.com/a/apereo.org/forum/#!msg/cas-user/H1vxChb6j_o/bTqvPJcmCwAJ 

for more detail in this issue